### PR TITLE
feat(tree-agent): Support staged allowed types in schema type generation

### DIFF
--- a/packages/framework/tree-agent/src/prompt.ts
+++ b/packages/framework/tree-agent/src/prompt.ts
@@ -386,15 +386,15 @@ export function stringifyTree(
  * @privateRemarks TODO: How do we keep this in sync with the actual `TreeArrayNode` docs if/when those docs change?
  */
 function getTreeArrayNodeDocumentation(typeName: string): string {
-	return `/** A special type of array which implements 'readonly T[]' (i.e. it supports all read-only JS array methods) and provides custom array mutation APIs. */
-export interface ${typeName}<T> extends ReadonlyArray<T> {
+	return `/** A special type of array which implements 'readonly TRead[]' (i.e. it supports all read-only JS array methods) and provides custom array mutation APIs. When the array has staged types, TRead includes staged types (for reading) while TWrite is restricted to non-staged types (for writing). */
+export interface ${typeName}<TRead, TWrite = TRead> extends ReadonlyArray<TRead> {
 	/**
 	 * Inserts new item(s) at a specified location.
 	 * @param index - The index at which to insert \`value\`.
 	 * @param value - The content to insert.
 	 * @throws Throws if \`index\` is not in the range [0, \`array.length\`).
 	 */
-	insertAt(index: number, ...value: readonly T[]): void;
+	insertAt(index: number, ...value: readonly TWrite[]): void;
 
 	/**
 	 * Removes the item at the specified location.
@@ -461,7 +461,7 @@ export interface ${typeName}<T> extends ReadonlyArray<T> {
 	 * @throws Throws if any of the source index is not in the range [0, \`array.length\`),
 	 * or if the index is not in the range [0, \`array.length\`].
 	 */
-	moveToIndex(destinationGap: number, sourceIndex: number, source?: ${typeName}<T>): void;
+	moveToIndex(destinationGap: number, sourceIndex: number, source?: ${typeName}<TRead, TWrite>): void;
 
 	/**
 	 * Moves the specified items to the desired location within the array.
@@ -510,7 +510,7 @@ export interface ${typeName}<T> extends ReadonlyArray<T> {
 		destinationGap: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source?: ${typeName}<T>,
+		source?: ${typeName}<TRead, TWrite>,
 	): void;
 }`;
 }
@@ -523,8 +523,9 @@ export interface ${typeName}<T> extends ReadonlyArray<T> {
 function getTreeMapNodeDocumentation(typeName: string): string {
 	return `/**
  * A map of string keys to tree objects.
+ * When the map has staged types, TRead includes staged types (for reading) while TWrite is restricted to non-staged types (for writing).
  */
-export interface ${typeName}<T> extends ReadonlyMap<string, T> {
+export interface ${typeName}<TRead, TWrite = TRead> extends ReadonlyMap<string, TRead> {
 	/**
 	 * Adds or updates an entry in the map with a specified \`key\` and a \`value\`.
 	 *
@@ -534,7 +535,7 @@ export interface ${typeName}<T> extends ReadonlyMap<string, T> {
 	 * @remarks
 	 * Setting the value at a key to \`undefined\` is equivalent to calling {@link ${typeName}.delete} with that key.
 	 */
-	set(key: string, value: T | undefined): void;
+	set(key: string, value: TWrite | undefined): void;
 
 	/**
 	 * Removes the specified element from this map by its \`key\`.
@@ -563,7 +564,7 @@ export interface ${typeName}<T> extends ReadonlyMap<string, T> {
 	 * Note: no guarantees are made regarding the order of the values returned.
 	 * If your usage scenario depends on consistent ordering, you will need to sort these yourself.
 	 */
-	values(): IterableIterator<T>;
+	values(): IterableIterator<TRead>;
 
 	/**
 	 * Returns an iterable of key/value pairs for every entry in the map.
@@ -572,7 +573,7 @@ export interface ${typeName}<T> extends ReadonlyMap<string, T> {
 	 * Note: no guarantees are made regarding the order of the entries returned.
 	 * If your usage scenario depends on consistent ordering, you will need to sort these yourself.
 	 */
-	entries(): IterableIterator<[string, T]>;
+	entries(): IterableIterator<[string, TRead]>;
 
 	/**
 	 * Executes the provided function once per each key/value pair in this map.
@@ -583,9 +584,9 @@ export interface ${typeName}<T> extends ReadonlyMap<string, T> {
 	 */
 	forEach(
 		callbackfn: (
-			value: T,
+			value: TRead,
 			key: string,
-			map: ReadonlyMap<string, T>,
+			map: ReadonlyMap<string, TRead>,
 		) => void,
 		thisArg?: any,
 	): void;

--- a/packages/framework/tree-agent/src/renderSchemaTypeScript.ts
+++ b/packages/framework/tree-agent/src/renderSchemaTypeScript.ts
@@ -8,11 +8,16 @@ import type { FieldSchema, TreeNodeSchema } from "@fluidframework/tree";
 import {
 	ArrayNodeSchema,
 	MapNodeSchema,
+	normalizeAllowedTypes,
 	ObjectNodeSchema,
 	RecordNodeSchema,
 } from "@fluidframework/tree/alpha";
 import { FieldKind, NodeKind, ValueSchema } from "@fluidframework/tree/internal";
-import type { SimpleLeafNodeSchema } from "@fluidframework/tree/internal";
+import type {
+	AllowedTypeMetadata,
+	AllowedTypesFull,
+	SimpleLeafNodeSchema,
+} from "@fluidframework/tree/internal";
 import {
 	isTypeFactoryType,
 	type TypeFactoryOptional,
@@ -49,6 +54,7 @@ interface BindingIntersectionResult {
 }
 
 interface TypeExpression {
+	staged?: boolean;
 	precedence: TypePrecedence;
 	text: string;
 }
@@ -207,14 +213,18 @@ export function renderSchemaTypeScript(
 	}
 
 	function renderFieldLine(name: string, field: FieldSchema): string[] {
-		const { comment, optional, type } = describeField(field);
+		const { comment, optional, type, setType } = describeField(field);
 		const lines: string[] = [];
 		if (comment !== undefined && comment !== "") {
 			for (const note of comment.split("\n")) {
 				lines.push(`// ${note}`);
 			}
 		}
-		lines.push(`${name}${optional ? "?" : ""}: ${type};`);
+		if (setType === undefined) {
+			lines.push(`${name}${optional ? "?" : ""}: ${type};`);
+		} else {
+			lines.push(`get ${name}(): ${type};\n\tset ${name}(value: ${setType});`);
+		}
 		return lines;
 	}
 
@@ -222,8 +232,10 @@ export function renderSchemaTypeScript(
 		comment?: string;
 		optional: boolean;
 		type: string;
+		setType?: string;
 	} {
-		const allowedTypes = renderAllowedTypes(field.allowedTypeSet);
+		const normalizedAllowedTypes = normalizeAllowedTypes(field.allowedTypes);
+		const allowedTypes = renderAnnotatedAllowedTypes(normalizedAllowedTypes);
 		const type = formatExpression(allowedTypes);
 		const optional = field.kind !== FieldKind.Required;
 		const customMetadata = field.metadata.custom as
@@ -260,6 +272,20 @@ export function renderSchemaTypeScript(
 		}
 
 		const description = field.metadata?.description;
+
+		if (allowedTypes.staged === true) {
+			const { types } = normalizedAllowedTypes.evaluate();
+			const nonStagedSchemas = types
+				.filter(({ metadata }) => metadata.stagedSchemaUpgrade === undefined)
+				.map(({ type: nodeSchema }) => nodeSchema);
+			const getType = formatExpression(allowedTypes, TypePrecedence.Union);
+			const setType = formatExpression(
+				renderAllowedTypes(nonStagedSchemas),
+				TypePrecedence.Union,
+			);
+			return { optional, type: getType, setType };
+		}
+
 		return {
 			optional,
 			type,
@@ -333,14 +359,42 @@ export function renderSchemaTypeScript(
 		};
 	}
 
-	function renderTypeReference(schema: TreeNodeSchema): TypeExpression {
+	function renderAnnotatedAllowedTypes(allowedTypes: AllowedTypesFull): TypeExpression {
+		const { types } = allowedTypes.evaluate();
+		const expressions: TypeExpression[] = [];
+		for (const { metadata, type } of types) {
+			expressions.push(renderTypeReference(type, metadata));
+		}
+		if (expressions.length === 0) {
+			return { precedence: TypePrecedence.Object, text: "never" };
+		}
+		if (expressions.length === 1) {
+			return expressions[0] ?? { precedence: TypePrecedence.Object, text: "never" };
+		}
+		const staged = expressions.some((e) => e.staged === true) ? true : undefined;
+		return {
+			staged,
+			precedence: TypePrecedence.Union,
+			text: expressions
+				.map((expr) => formatExpression(expr, TypePrecedence.Union))
+				.join(" | "),
+		};
+	}
+
+	function renderTypeReference(
+		schema: TreeNodeSchema,
+		metadata?: AllowedTypeMetadata,
+	): TypeExpression {
+		const staged = metadata?.stagedSchemaUpgrade === undefined ? undefined : true;
 		if (isNamedSchema(schema.identifier)) {
 			return {
+				staged,
 				precedence: TypePrecedence.Object,
 				text: resolver.resolve(schema),
 			};
 		}
-		return renderInlineSchema(schema);
+		const result = renderInlineSchema(schema);
+		return staged === undefined ? result : { ...result, staged };
 	}
 
 	function renderInlineSchema(schema: TreeNodeSchema): TypeExpression {

--- a/packages/framework/tree-agent/src/renderSchemaTypeScript.ts
+++ b/packages/framework/tree-agent/src/renderSchemaTypeScript.ts
@@ -225,12 +225,22 @@ export function renderSchemaTypeScript(
 		name: string,
 		schema: RecordNodeSchema,
 	): RenderResult {
-		const valueType = renderAllowedTypes(schema.childTypes);
-		const base = `Record<string, ${valueType.text}>`;
+		const valueType = renderAnnotatedChildTypes(schema);
 		const binding = renderBindingIntersection(definition);
+		let description = schema.metadata?.description;
+		if (valueType.staged === true) {
+			const stagedTypes = [...schema.childTypes].filter(
+				(child) => schema.simpleAllowedTypes.get(child.identifier)?.isStaged !== false,
+			);
+			const stagedTypeList = formatExpression(renderAllowedTypes(stagedTypes));
+			const note = `Warning: do not set record values to any of the following types (they are staged and not yet writeable): ${stagedTypeList}`;
+			description =
+				description !== undefined && description !== "" ? `${description}\n${note}` : note;
+		}
+		const base = `Record<string, ${valueType.text}>`;
 		return {
 			declaration: `type ${name} = ${base}${binding.suffix};`,
-			description: describeBinding(schema.metadata?.description, "record", binding),
+			description: describeBinding(description, "record", binding),
 		};
 	}
 

--- a/packages/framework/tree-agent/src/renderSchemaTypeScript.ts
+++ b/packages/framework/tree-agent/src/renderSchemaTypeScript.ts
@@ -175,9 +175,20 @@ export function renderSchemaTypeScript(
 		name: string,
 		schema: ArrayNodeSchema,
 	): RenderResult {
-		const elementTypes = renderAllowedTypes(schema.childTypes);
-		const base = `${formatExpression(elementTypes)}[]`;
+		const elementTypes = renderAnnotatedChildTypes(schema);
 		const binding = renderBindingIntersection(definition);
+		if (elementTypes.staged === true) {
+			const nonStagedTypes = [...schema.childTypes].filter(
+				(child) => schema.simpleAllowedTypes.get(child.identifier)?.isStaged === false,
+			);
+			const readType = formatExpression(elementTypes);
+			const writeType = formatExpression(renderAllowedTypes(nonStagedTypes));
+			return {
+				declaration: `type ${name} = TreeArray<${readType}, ${writeType}>${binding.suffix};`,
+				description: describeBinding(schema.metadata?.description, "array", binding),
+			};
+		}
+		const base = `${formatExpression(elementTypes)}[]`;
 		return {
 			declaration: `type ${name} = ${base}${binding.suffix};`,
 			description: describeBinding(schema.metadata?.description, "array", binding),
@@ -189,9 +200,20 @@ export function renderSchemaTypeScript(
 		name: string,
 		schema: MapNodeSchema,
 	): RenderResult {
-		const valueType = renderAllowedTypes(schema.childTypes);
-		const base = `Map<string, ${valueType.text}>`;
+		const valueType = renderAnnotatedChildTypes(schema);
 		const binding = renderBindingIntersection(definition);
+		if (valueType.staged === true) {
+			const nonStagedTypes = [...schema.childTypes].filter(
+				(child) => schema.simpleAllowedTypes.get(child.identifier)?.isStaged === false,
+			);
+			const readType = formatExpression(valueType);
+			const writeType = formatExpression(renderAllowedTypes(nonStagedTypes));
+			return {
+				declaration: `type ${name} = TreeMap<${readType}, ${writeType}>${binding.suffix};`,
+				description: describeBinding(schema.metadata?.description, "map", binding),
+			};
+		}
+		const base = `Map<string, ${valueType.text}>`;
 		return {
 			declaration: `type ${name} = ${base}${binding.suffix};`,
 			description: describeBinding(schema.metadata?.description, "map", binding),
@@ -352,6 +374,42 @@ export function renderSchemaTypeScript(
 			return expressions[0] ?? { precedence: TypePrecedence.Object, text: "never" };
 		}
 		return {
+			precedence: TypePrecedence.Union,
+			text: expressions
+				.map((expr) => formatExpression(expr, TypePrecedence.Union))
+				.join(" | "),
+		};
+	}
+
+	function renderAnnotatedChildTypes(
+		schema: ArrayNodeSchema | MapNodeSchema | RecordNodeSchema,
+	): TypeExpression {
+		const expressions: TypeExpression[] = [];
+		for (const childSchema of schema.childTypes) {
+			const isStaged =
+				schema.simpleAllowedTypes.get(childSchema.identifier)?.isStaged !== false;
+			let expr: TypeExpression;
+			if (isNamedSchema(childSchema.identifier)) {
+				expr = {
+					staged: isStaged ? true : undefined,
+					precedence: TypePrecedence.Object,
+					text: resolver.resolve(childSchema),
+				};
+			} else {
+				const result = renderInlineSchema(childSchema);
+				expr = isStaged ? { ...result, staged: true } : result;
+			}
+			expressions.push(expr);
+		}
+		if (expressions.length === 0) {
+			return { precedence: TypePrecedence.Object, text: "never" };
+		}
+		if (expressions.length === 1) {
+			return expressions[0] ?? { precedence: TypePrecedence.Object, text: "never" };
+		}
+		const staged = expressions.some((e) => e.staged === true) ? (true as const) : undefined;
+		return {
+			staged,
 			precedence: TypePrecedence.Union,
 			text: expressions
 				.map((expr) => formatExpression(expr, TypePrecedence.Union))

--- a/packages/framework/tree-agent/src/test/__snapshots__/prompt.md
+++ b/packages/framework/tree-agent/src/test/__snapshots__/prompt.md
@@ -165,15 +165,15 @@ However, write operations (e.g. index assignment, `push`, `pop`, `splice`, etc.)
 Instead, you must use the methods on the following interface to mutate the array:
 
 ```typescript
-/** A special type of array which implements 'readonly T[]' (i.e. it supports all read-only JS array methods) and provides custom array mutation APIs. */
-export interface TreeArray<T> extends ReadonlyArray<T> {
+/** A special type of array which implements 'readonly TRead[]' (i.e. it supports all read-only JS array methods) and provides custom array mutation APIs. When the array has staged types, TRead includes staged types (for reading) while TWrite is restricted to non-staged types (for writing). */
+export interface TreeArray<TRead, TWrite = TRead> extends ReadonlyArray<TRead> {
 	/**
 	 * Inserts new item(s) at a specified location.
 	 * @param index - The index at which to insert `value`.
 	 * @param value - The content to insert.
 	 * @throws Throws if `index` is not in the range [0, `array.length`).
 	 */
-	insertAt(index: number, ...value: readonly T[]): void;
+	insertAt(index: number, ...value: readonly TWrite[]): void;
 
 	/**
 	 * Removes the item at the specified location.
@@ -240,7 +240,7 @@ export interface TreeArray<T> extends ReadonlyArray<T> {
 	 * @throws Throws if any of the source index is not in the range [0, `array.length`),
 	 * or if the index is not in the range [0, `array.length`].
 	 */
-	moveToIndex(destinationGap: number, sourceIndex: number, source?: TreeArray<T>): void;
+	moveToIndex(destinationGap: number, sourceIndex: number, source?: TreeArray<TRead, TWrite>): void;
 
 	/**
 	 * Moves the specified items to the desired location within the array.
@@ -289,7 +289,7 @@ export interface TreeArray<T> extends ReadonlyArray<T> {
 		destinationGap: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source?: TreeArray<T>,
+		source?: TreeArray<TRead, TWrite>,
 	): void;
 }
 ```
@@ -308,8 +308,9 @@ Instead, you must use the methods on the following interface to mutate the map:
 ```typescript
 /**
  * A map of string keys to tree objects.
+ * When the map has staged types, TRead includes staged types (for reading) while TWrite is restricted to non-staged types (for writing).
  */
-export interface TreeMap<T> extends ReadonlyMap<string, T> {
+export interface TreeMap<TRead, TWrite = TRead> extends ReadonlyMap<string, TRead> {
 	/**
 	 * Adds or updates an entry in the map with a specified `key` and a `value`.
 	 *
@@ -319,7 +320,7 @@ export interface TreeMap<T> extends ReadonlyMap<string, T> {
 	 * @remarks
 	 * Setting the value at a key to `undefined` is equivalent to calling {@link TreeMap.delete} with that key.
 	 */
-	set(key: string, value: T | undefined): void;
+	set(key: string, value: TWrite | undefined): void;
 
 	/**
 	 * Removes the specified element from this map by its `key`.
@@ -348,7 +349,7 @@ export interface TreeMap<T> extends ReadonlyMap<string, T> {
 	 * Note: no guarantees are made regarding the order of the values returned.
 	 * If your usage scenario depends on consistent ordering, you will need to sort these yourself.
 	 */
-	values(): IterableIterator<T>;
+	values(): IterableIterator<TRead>;
 
 	/**
 	 * Returns an iterable of key/value pairs for every entry in the map.
@@ -357,7 +358,7 @@ export interface TreeMap<T> extends ReadonlyMap<string, T> {
 	 * Note: no guarantees are made regarding the order of the entries returned.
 	 * If your usage scenario depends on consistent ordering, you will need to sort these yourself.
 	 */
-	entries(): IterableIterator<[string, T]>;
+	entries(): IterableIterator<[string, TRead]>;
 
 	/**
 	 * Executes the provided function once per each key/value pair in this map.
@@ -368,9 +369,9 @@ export interface TreeMap<T> extends ReadonlyMap<string, T> {
 	 */
 	forEach(
 		callbackfn: (
-			value: T,
+			value: TRead,
 			key: string,
-			map: ReadonlyMap<string, T>,
+			map: ReadonlyMap<string, TRead>,
 		) => void,
 		thisArg?: any,
 	): void;

--- a/packages/framework/tree-agent/src/test/typeGeneration.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeGeneration.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
+import { SchemaFactoryAlpha } from "@fluidframework/tree/alpha";
 import {
 	getSimpleSchema,
 	independentView,
@@ -377,6 +378,7 @@ type MapWithProperty = Map<string, string> & {
 
 	describe("handles staged allowed types", () => {
 		const sfBeta = new SchemaFactoryBeta("staged-type-tests");
+		const sfAlpha = new SchemaFactoryAlpha("staged-type-tests");
 
 		it("for object nodes", () => {
 			class ObjWithStagedType extends sfBeta.object("ObjWithStagedType", {
@@ -428,7 +430,43 @@ type MapWithProperty = Map<string, string> & {
 			assert.deepEqual(schemaString, `type StagedMap = TreeMap<(string | number), string>;\n`);
 		});
 
+		it("for record nodes", () => {
+			class StagedRecord extends sfAlpha.recordAlpha(
+				"StagedRecord",
+				SchemaFactoryBeta.types([
+					SchemaFactoryBeta.string,
+					SchemaFactoryBeta.staged(SchemaFactoryBeta.number),
+				]),
+			) {}
 
+			const schemaString = getDomainSchemaString(StagedRecord, { a: "alpha" });
+			assert.deepEqual(
+				schemaString,
+				`// Warning: do not set record values to any of the following types (they are staged and not yet writeable): number\ntype StagedRecord = Record<string, string | number>;\n`,
+			);
+		});
+
+		it("record nodes throw a runtime error when writing a staged type", () => {
+			class StagedRecord extends sfAlpha.recordAlpha(
+				"StagedRecord2",
+				SchemaFactoryBeta.types([
+					SchemaFactoryBeta.string,
+					SchemaFactoryBeta.staged(SchemaFactoryBeta.number),
+				]),
+			) {}
+
+			const view = independentView(new TreeViewConfiguration({ schema: StagedRecord }));
+			view.initialize({ a: "alpha" });
+			const record = view.root;
+
+			// Writing a string (non-staged) should succeed
+			record.a = "updated";
+
+			// Writing a number (staged type) should throw at runtime
+			assert.throws(() => {
+				record.b = 42;
+			});
+		});
 	});
 });
 

--- a/packages/framework/tree-agent/src/test/typeGeneration.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeGeneration.spec.ts
@@ -398,6 +398,37 @@ type MapWithProperty = Map<string, string> & {
 `,
 			);
 		});
+
+		it("for array nodes", () => {
+			class StagedArray extends sfBeta.array(
+				"StagedArray",
+				SchemaFactoryBeta.types([
+					SchemaFactoryBeta.string,
+					SchemaFactoryBeta.staged(SchemaFactoryBeta.number),
+				]),
+			) {}
+
+			const schemaString = getDomainSchemaString(StagedArray, ["hello"]);
+			assert.deepEqual(
+				schemaString,
+				`type StagedArray = TreeArray<(string | number), string>;\n`,
+			);
+		});
+
+		it("for map nodes", () => {
+			class StagedMap extends sfBeta.map(
+				"StagedMap",
+				SchemaFactoryBeta.types([
+					SchemaFactoryBeta.string,
+					SchemaFactoryBeta.staged(SchemaFactoryBeta.number),
+				]),
+			) {}
+
+			const schemaString = getDomainSchemaString(StagedMap, new Map([["a", "alpha"]]));
+			assert.deepEqual(schemaString, `type StagedMap = TreeMap<(string | number), string>;\n`);
+		});
+
+
 	});
 });
 

--- a/packages/framework/tree-agent/src/test/typeGeneration.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeGeneration.spec.ts
@@ -9,6 +9,7 @@ import {
 	getSimpleSchema,
 	independentView,
 	SchemaFactory,
+	SchemaFactoryBeta,
 	TreeViewConfiguration,
 	type ImplicitFieldSchema,
 	type InsertableField,
@@ -372,6 +373,31 @@ type MapWithProperty = Map<string, string> & {
 			schemaText.includes("interface Foo_2_2"),
 			"Natural Foo_2 becomes Foo_2_2 since Foo_2 was taken",
 		);
+	});
+
+	describe("handles staged allowed types", () => {
+		const sfBeta = new SchemaFactoryBeta("staged-type-tests");
+
+		it("for object nodes", () => {
+			class ObjWithStagedType extends sfBeta.object("ObjWithStagedType", {
+				foo: SchemaFactoryBeta.types([
+					SchemaFactoryBeta.string,
+					SchemaFactoryBeta.staged(SchemaFactoryBeta.number),
+				]),
+			}) {}
+
+			const objectDomainSchemaString = getDomainSchemaString(ObjWithStagedType, {
+				foo: "test",
+			});
+			assert.deepEqual(
+				objectDomainSchemaString,
+				`interface ObjWithStagedType {
+    get foo(): string | number;
+	set foo(value: string);
+}
+`,
+			);
+		});
 	});
 });
 


### PR DESCRIPTION
## Description

Adds support for staged allowed types in the tree-agent's TypeScript schema rendering. Staged types are types that can be read from a node but cannot yet be written — they represent a forward-compatible schema upgrade that has not been fully committed.

Previously, the type generator treated all allowed types uniformly for reads and writes. With this change:

- **Array and map nodes** with staged types render as `TreeArray<TRead, TWrite>` / `TreeMap<TRead, TWrite>`, where `TRead` includes staged types and `TWrite` excludes them.
- **Object node fields** with staged types render as getter/setter pairs (`get foo(): string | number; set foo(value: string);`) instead of simple properties, enforcing write-time restrictions.
- **Record nodes** include a warning comment noting which types are staged and not writeable.
- The `TreeArray` and `TreeMap` prompt documentation is updated to reflect the dual type parameter pattern.

Also migrates several imports (`isTypeFactoryType`, `ExposedMethods`, `ExposedProperties`, etc.) from local re-exports to their canonical sources in `@fluidframework/type-factory`, and updates `methods.expose()` → `methods.exposeMethod()` to match the current API.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The core logic is in `renderSchemaTypeScript.ts` — the new `renderAnnotatedChildTypes` and `renderAnnotatedAllowedTypes` helpers propagate a `staged` flag through `TypeExpression`, which the array/map/record/object renderers then use to split read vs. write types.
- Tests in `typeGeneration.spec.ts` cover all four node kinds (object, array, map, record) and include a runtime assertion that writing a staged type to a record throws.
